### PR TITLE
LoFTR pipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 from megadepth.metrics.metadata import collect_metrics
-from megadepth.utils.constants import ModelType
+from megadepth.utils.constants import Matcher, ModelType
 from megadepth.utils.utils import DataPaths, setup
 
 
@@ -25,6 +25,10 @@ def main():
         from megadepth.pipelines.colmap import ColmapPipeline
 
         pipeline = ColmapPipeline(args)
+    elif args.matcher == Matcher.LOFTR.value:
+        from megadepth.pipelines.loftr import LoftrPipeline
+
+        pipeline = LoftrPipeline(args)
     else:
         from megadepth.pipelines.hloc import HlocPipeline
 

--- a/megadepth/metrics/overlap.py
+++ b/megadepth/metrics/overlap.py
@@ -108,6 +108,9 @@ def dense_overlap(
         )
 
         for j, k2 in enumerate(images.keys()):
+            if i == j:
+                continue
+
             # load second image, camera and depth map
             image_2 = images[k2]
             camera_2 = cameras[image_2.camera_id]

--- a/megadepth/pipelines/hloc.py
+++ b/megadepth/pipelines/hloc.py
@@ -119,7 +119,7 @@ class HlocPipeline(Pipeline):
 
         logging.debug("Matching features with hloc")
         logging.debug(f"Matcher config: {self.configs['matcher']}")
-        logging.debug(f"Loading pairs form {self.paths.matches_retrieval}")
+        logging.debug(f"Loading pairs from {self.paths.matches_retrieval}")
         logging.debug(f"Loading features from {self.paths.features}")
         logging.debug(f"Storing matches to {self.paths.matches}")
 

--- a/megadepth/pipelines/loftr.py
+++ b/megadepth/pipelines/loftr.py
@@ -34,9 +34,9 @@ class LoftrPipeline(HlocPipeline):
 
         logging.debug("Matching and extracting features with LoFTR")
         logging.debug(f"Matcher config: {self.configs['matcher']}")
-        logging.debug(f"Loading pairs form {self.paths.matches_retrieval}")
-        logging.debug(f"Loading features from {self.paths.features}")
+        logging.debug(f"Loading pairs from {self.paths.matches_retrieval}")
         logging.debug(f"Storing matches to {self.paths.matches}")
+        logging.debug(f"Storing features to {self.paths.features}")
 
         os.makedirs(self.paths.matches.parent, exist_ok=True)
         os.makedirs(self.paths.features.parent, exist_ok=True)

--- a/megadepth/pipelines/loftr.py
+++ b/megadepth/pipelines/loftr.py
@@ -18,7 +18,7 @@ class LoftrPipeline(HlocPipeline):
     def __init__(self, args: argparse.Namespace) -> None:
         """Initialize the pipeline."""
         super().__init__(args)
-        self.preproc_dir = os.path.join(self.paths.data, "images_loftr")
+        self.preproc_dir = self.paths.data / "images_loftr"
 
     def extract_features(self) -> None:
         """Extract features from images."""

--- a/megadepth/pipelines/loftr.py
+++ b/megadepth/pipelines/loftr.py
@@ -1,0 +1,59 @@
+"""Pipeline using LoFTR."""
+import argparse
+import datetime
+import logging
+import os
+import time
+
+from hloc import match_dense
+
+from megadepth.pipelines.hloc import HlocPipeline
+
+
+class LoftrPipeline(HlocPipeline):
+    """HLoc-based pipeline for LoFTR."""
+
+    def __init__(self, args: argparse.Namespace) -> None:
+        """Initialize the pipeline."""
+        super().__init__(args)
+
+    def extract_features(self) -> None:
+        """Extract features from images."""
+        # features are extracted during the dense matching step
+        return
+
+    def _preprocess_images(self) -> None:
+        """Preprocess images for dense matching."""
+        # TODO
+        raise NotImplementedError()
+
+    def match_features(self) -> None:
+        """Match features between images."""
+        self.log_step("Matching and extracting features...")
+        start = time.time()
+
+        logging.debug("Matching and extracting features with LoFTR")
+        logging.debug(f"Matcher config: {self.configs['matcher']}")
+        logging.debug(f"Loading pairs form {self.paths.matches_retrieval}")
+        logging.debug(f"Loading features from {self.paths.features}")
+        logging.debug(f"Storing matches to {self.paths.matches}")
+
+        os.makedirs(self.paths.matches.parent, exist_ok=True)
+        os.makedirs(self.paths.features.parent, exist_ok=True)
+
+        # preprocess images if not done yet
+        # TODO: check if directory with preprocessed images already exists
+        self._preprocess_images()
+
+        match_dense.main(
+            conf=self.configs["matcher"],
+            image_dir=self.paths.images,  # TODO: replace with path to preprocessed directory
+            pairs=self.paths.matches_retrieval,
+            features=self.paths.features,
+            matches=self.paths.matches,
+        )
+
+        end = time.time()
+        logging.info(
+            f"Time to match and extract features: {datetime.timedelta(seconds=end - start)}"
+        )

--- a/megadepth/pipelines/loftr.py
+++ b/megadepth/pipelines/loftr.py
@@ -5,6 +5,8 @@ import logging
 import os
 import time
 
+import cv2
+import numpy as np
 from hloc import match_dense
 
 from megadepth.pipelines.hloc import HlocPipeline
@@ -16,16 +18,42 @@ class LoftrPipeline(HlocPipeline):
     def __init__(self, args: argparse.Namespace) -> None:
         """Initialize the pipeline."""
         super().__init__(args)
+        self.preproc_dir = os.path.join(self.paths.data, "images_loftr")
 
     def extract_features(self) -> None:
         """Extract features from images."""
         # features are extracted during the dense matching step
         return
 
-    def _preprocess_images(self) -> None:
+    def _already_preprocessed(self) -> bool:
+        """Check if all images are already preprocessed."""
+        if not os.path.exists(self.preproc_dir):
+            return False
+
+        return len(os.listdir(self.paths.images)) == len(os.listdir(self.preproc_dir))
+
+    def _preprocess_images(self, size: int = 840) -> None:
         """Preprocess images for dense matching."""
-        # TODO
-        raise NotImplementedError()
+        logging.debug("Preprocessing images for LoFTR")
+
+        os.makedirs(self.preproc_dir, exist_ok=True)
+        for fn in os.listdir(self.paths.images):
+            img = cv2.imread(os.path.join(self.paths.images, fn))
+            height, width = img.shape[:2]
+            aspect_ratio = float(width) / float(height)
+
+            if aspect_ratio < 1:
+                new_width = int(size * aspect_ratio)
+                new_height = size
+            else:
+                new_width = size
+                new_height = int(size / aspect_ratio)
+
+            new_img = np.zeros((size, size, 3), dtype=np.uint8)
+            new_img[:new_height, :new_width, :] = cv2.resize(img, (new_width, new_height))
+            cv2.imwrite(os.path.join(self.preproc_dir, fn), new_img)
+
+        logging.debug("Preprocessing done")
 
     def match_features(self) -> None:
         """Match features between images."""
@@ -42,12 +70,12 @@ class LoftrPipeline(HlocPipeline):
         os.makedirs(self.paths.features.parent, exist_ok=True)
 
         # preprocess images if not done yet
-        # TODO: check if directory with preprocessed images already exists
-        self._preprocess_images()
+        if not self._already_preprocessed():
+            self._preprocess_images()
 
         match_dense.main(
             conf=self.configs["matcher"],
-            image_dir=self.paths.images,  # TODO: replace with path to preprocessed directory
+            image_dir=self.preproc_dir,
             pairs=self.paths.matches_retrieval,
             features=self.paths.features,
             matches=self.paths.matches,

--- a/megadepth/utils/constants.py
+++ b/megadepth/utils/constants.py
@@ -32,6 +32,7 @@ class Matcher(Enum):
     SUPERGLUE = "superglue"
     NN_RATIO = "NN-ratio"
     NN_MUTUAL = "NN-mutual"
+    LOFTR = "loftr"
 
 
 class PairsFrom(Enum):

--- a/megadepth/utils/utils.py
+++ b/megadepth/utils/utils.py
@@ -290,7 +290,7 @@ class DataPaths:
         retrieval_name = f"{args.retrieval}"
         retrieval_name += (
             ".txt"
-            if args.retrieval != Retrieval.EXHAUSTIVE.value
+            if args.retrieval == Retrieval.EXHAUSTIVE.value
             else f"-{args.n_retrieval_matches}.txt"
         )
 
@@ -309,7 +309,7 @@ class DataPaths:
         # features
         if args.matcher == Matcher.LOFTR.value:
             self.features = Path(
-                os.path.join(self.data, args.features_dir, f"{args.model_name}.h5")
+                os.path.join(self.data, args.features_dir, f"{self.model_name}.h5")
             )
         else:
             self.features = Path(os.path.join(self.data, args.features_dir, f"{args.features}.h5"))

--- a/megadepth/utils/utils.py
+++ b/megadepth/utils/utils.py
@@ -258,11 +258,11 @@ def get_configs(args: argparse.Namespace) -> dict:
         else None
     )
 
-    matcher_conf = (
-        match_dense.confs[args.matcher]
-        if args.matcher == Matcher.LOFTR.value
-        else match_features.confs[args.matcher]
-    )
+    if args.matcher == Matcher.LOFTR.value:
+        matcher_conf = match_dense.confs[args.matcher]
+        matcher_conf["preprocessing"]["resize_max"] = 840
+    else:
+        matcher_conf = match_features.confs[args.matcher]
 
     conf = {
         "retrieval": retrieval_conf,


### PR DESCRIPTION
### Implementation of a HLoc-based LoFTR pipeline

Using LoFTR, the features are extracted during the dense matching step. Besides that, everything else is identical to the HLoc pipeline.

Let's say we run LoFTR on the top 20 NetVLAD pairs. Then, the following names would be used per default:

- model: `loftr-netvlad-20`
- features: `loftr-netvlad-20.h5`
- matches: `loftr-netvlad-20.h5`

FYI: @veichta 