### PR TITLE
Update overlap scores

### DIFF
--- a/megadepth/metrics/metadata.py
+++ b/megadepth/metrics/metadata.py
@@ -51,7 +51,7 @@ def collect_metrics(paths: DictConfig, config: DictConfig, model_type: str) -> D
     metrics["perc_reg_images"] = metrics["n_reg_images"] / n_images * 100
 
     # mean overlap
-    metrics["mean_overlap"] = np.mean(overlap)
+    metrics["mean_overlap"] = np.mean(overlap.data)
 
     # add pipeline information
     metrics["scene"] = str(config.scene)
@@ -69,10 +69,9 @@ def collect_metrics(paths: DictConfig, config: DictConfig, model_type: str) -> D
 
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
-    overlap_fn = f"{model_type}-overlap-{timestamp}.npy"
+    overlap_fn = f"{model_type}-overlap-{timestamp}.nc"
+    overlap.to_netcdf(os.path.join(paths.metrics, overlap_fn))
     metrics["overlap_fn"] = overlap_fn
-    with open(os.path.join(paths.metrics, overlap_fn), "wb") as f_overlap:
-        np.save(f_overlap, overlap)
 
     with open(os.path.join(paths.metrics, f"{model_type}-{timestamp}.json"), "w") as f_metric:
         json.dump(metrics, f_metric, indent=4)

--- a/megadepth/metrics/metadata.py
+++ b/megadepth/metrics/metadata.py
@@ -4,8 +4,7 @@ import datetime
 import json
 import logging
 import os
-from pathlib import Path
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple
 
 import numpy as np
 import pycolmap
@@ -28,8 +27,7 @@ def collect_metrics(paths: DictConfig, config: DictConfig, model_type: str) -> D
     """
     if model_type == "dense":
         reconstruction = pycolmap.Reconstruction(os.path.join(paths.dense, "sparse"))
-        depth_map_path = os.path.join(paths.dense, "stereo", "depth_maps")
-        metrics, overlap = collect_dense(reconstruction, depth_map_path)
+        metrics, overlap = collect_dense(reconstruction, paths)
     elif model_type == "sparse":
         reconstruction = pycolmap.Reconstruction(paths.sparse)
         metrics, overlap = collect_sparse(reconstruction)
@@ -101,13 +99,13 @@ def collect_sparse(reconstruction: pycolmap.Reconstruction) -> Tuple[Dict[str, A
 
 
 def collect_dense(
-    reconstruction: pycolmap.Reconstruction, depth_map_path: Union[Path, str]
+    reconstruction: pycolmap.Reconstruction, paths: DictConfig
 ) -> Tuple[Dict[str, Any], np.ndarray]:
     """Collect metrics for a dense COLMAP reconstruction.
 
     Args:
         reconstruction: The dense reconstruction.
-        depth_map_path: Path to the directory that contains the depth maps.
+        paths: The data paths for the reconstruction.
 
     Returns:
         A dictionary containing the metrics and a numpy array containing the overlap scores.
@@ -121,6 +119,6 @@ def collect_dense(
     }
     # TODO: add metrics if we loose some images during dense reconstruction
 
-    overlap = dense_overlap(reconstruction, depth_map_path)
+    overlap = dense_overlap(paths)
 
     return metrics, overlap

--- a/megadepth/metrics/overlap.py
+++ b/megadepth/metrics/overlap.py
@@ -1,12 +1,14 @@
 """Functions to compute the overlap metrics between a list of images."""
 
+import logging
 import os
-from pathlib import Path
-from typing import Optional, Union
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from typing import Tuple
 
 import numpy as np
 import pycolmap
 import xarray as xr
+from omegaconf import DictConfig
 from tqdm import tqdm
 
 from megadepth.utils.io import load_depth_map
@@ -30,8 +32,8 @@ def sparse_overlap(reconstruction: pycolmap.Reconstruction) -> xr.DataArray:
         xr.DataArray: DataArray of shape (N, N) with the overlap metric between each pair of images.
     """
     images = reconstruction.images
-    N = len(images)
     image_fns = [images[k].name for k in images.keys()]
+    N = len(images)
 
     # pre-compute hash sets with 3D point IDs for faster lookups later
     img_to_ids = {}
@@ -57,13 +59,101 @@ def sparse_overlap(reconstruction: pycolmap.Reconstruction) -> xr.DataArray:
     return xr.DataArray(scores, coords=coords, dims=["img1", "img2"])
 
 
+def _compute_dense_row(
+    i: int,
+    k1: int,
+    paths: DictConfig,
+    downsample: int,
+    rel_thresh: float,
+    cosine_weighted: bool,
+) -> Tuple[int, np.ndarray]:
+    """Compute the i-th row of the dense overlap matrix."""
+    reconstruction = pycolmap.Reconstruction(os.path.join(paths.dense, "sparse"))
+    depth_path = os.path.join(paths.dense, "stereo", "depth_maps")
+    normal_path = os.path.join(paths.dense, "stereo", "normal_maps")
+
+    cameras = reconstruction.cameras
+    images = reconstruction.images
+    N = len(images)
+
+    row = np.full((N,), 100, dtype=np.int8)
+
+    # load first image, camera and depth map
+    image_1 = images[k1]
+    camera_1 = cameras[image_1.camera_id]
+    depth_map_1 = load_depth_map(os.path.join(depth_path, f"{image_1.name}.geometric.bin"))
+
+    # gather depth values that we want to check in a vector
+    depth_1 = depth_map_1[::downsample, ::downsample].ravel()
+
+    # get the corresponding 2D coordinates in image 1
+    points_2d = camera_pixel_grid(camera_1, downsample)
+
+    # filter out invalid depth values
+    valid_depth_mask = depth_1 > 0.0
+    depth_1 = depth_1[valid_depth_mask]
+    points_2d = points_2d[valid_depth_mask]
+
+    # number of dense features we are considering for the score computation
+    n_features = depth_1.size
+
+    # backproject all valid 2D points from image 1 to 3D
+    points_3d = backward_project(
+        points_2d=points_2d,
+        image=image_1,
+        camera=camera_1,
+        depth=depth_1,
+    )
+
+    for j, k2 in enumerate(images.keys()):
+        if i == j and not cosine_weighted:
+            continue
+
+        # load second image, camera and depth map
+        image_2 = images[k2]
+        camera_2 = cameras[image_2.camera_id]
+        depth_map_2 = load_depth_map(os.path.join(depth_path, f"{image_2.name}.geometric.bin"))
+
+        # project all 3D points to image 2 to obtain 2D points and associated depth values
+        proj_points_2d, proj_depths, proj_mask = forward_project(
+            points_3d=points_3d,
+            image=image_2,
+            camera=camera_2,
+        )
+
+        # get corresponding depth values from the second depth map
+        # depth map values are stored row-wise => first index with y-coordinate
+        depth_2 = depth_map_2[proj_points_2d[:, 1], proj_points_2d[:, 0]]
+
+        # compute inliers based on the absolute relative depth errors
+        abs_rel_error = np.abs(depth_2 / proj_depths - 1.0)
+        if cosine_weighted:
+            normal_map_1 = load_depth_map(
+                os.path.join(str(normal_path), f"{image_1.name}.geometric.bin")
+            )
+            normal_map_2 = load_depth_map(
+                os.path.join(str(normal_path), f"{image_2.name}.geometric.bin")
+            )
+            norm_1 = normal_map_1[
+                points_2d[proj_mask][:, 1].astype(int), points_2d[proj_mask][:, 0].astype(int)
+            ]
+            norm_2 = normal_map_2[proj_points_2d[:, 1], proj_points_2d[:, 0]]
+            cos_w_2 = np.minimum(np.abs(norm_1[:, 2]), np.abs(norm_2[:, 2]))
+            n_inliners = np.sum(cos_w_2[abs_rel_error < rel_thresh])
+        else:
+            n_inliners = np.count_nonzero(abs_rel_error < rel_thresh)
+
+        # final score
+        row[j] = np.rint(100 * n_inliners / n_features)
+
+    return (i, row)  # add row index because the tasks for each row don't finish in-order
+
+
 def dense_overlap(
-    reconstruction: pycolmap.Reconstruction,
-    depth_path: Union[Path, str],
+    paths: DictConfig,
     downsample: int = 50,
     rel_thresh: float = 0.03,
     cosine_weighted: bool = False,
-    normal_path: Optional[Union[Path, str]] = None,
 ) -> xr.DataArray:
     """Computes the dense overlap metric between a list of images.
 
@@ -72,93 +162,42 @@ def dense_overlap(
     integer in the range [0, 100].
 
     Args:
-        reconstruction (pycolmap.Reconstruction): Reconstruction object.
-        depth_path (Union[Path, str]): Path to the directory that contains the depth maps.
+        paths (DictConfig): Data paths.
         downsample (int, optional): By which factor to downsample depth maps.
         rel_thresh (float, optional): Dense points with an absolute relative depth error below this
             threshold are considered as inliers.
         cosine_weighted (bool): Whether to cosine-weight the overlap scores. Defaults to False.
-        normal_path (Optional[Union[Path, str]]): Path to the directory that contains the normal
-            maps. Required if `cosine_weighted` is set to True.
 
     Returns:
         xr.DataArray: DataArray of shape (N, N) with the overlap metric between each pair of images.
     """
-    cameras = reconstruction.cameras
+    reconstruction = pycolmap.Reconstruction(os.path.join(paths.dense, "sparse"))
     images = reconstruction.images
-    N = len(images)
     image_fns = [images[k].name for k in images.keys()]
+    N = len(images)
+
+    # args for subprocesses
+    kwargs = dict(
+        paths=paths,
+        downsample=downsample,
+        rel_thresh=rel_thresh,
+        cosine_weighted=cosine_weighted,
+    )
 
     # compute overlap scores for each image pair
     scores = np.full((N, N), 100, dtype=np.int8)
-    for i, k1 in enumerate(tqdm(images.keys(), desc="Computing dense overlap...", ncols=80)):
-        # load first image, camera and depth map
-        image_1 = images[k1]
-        camera_1 = cameras[image_1.camera_id]
-        depth_map_1 = load_depth_map(os.path.join(depth_path, f"{image_1.name}.geometric.bin"))
+    with ProcessPoolExecutor() as executor:
+        logging.info(f"Using {executor._max_workers} workers to compute the dense overlap.")
 
-        # gather depth values that we want to check in a vector
-        depth_1 = depth_map_1[::downsample, ::downsample].ravel()
+        futures = [
+            executor.submit(_compute_dense_row, i, k1, **kwargs)
+            for i, k1 in enumerate(images.keys())
+        ]
 
-        # get the corresponding 2D coordinates in image 1
-        points_2d = camera_pixel_grid(camera_1, downsample)
-
-        # filter out invalid depth values
-        valid_depth_mask = depth_1 > 0.0
-        depth_1 = depth_1[valid_depth_mask]
-        points_2d = points_2d[valid_depth_mask]
-
-        # number of dense features we are considering for the score computation
-        n_features = depth_1.size
-
-        # backproject all valid 2D points from image 1 to 3D
-        points_3d = backward_project(
-            points_2d=points_2d,
-            image=image_1,
-            camera=camera_1,
-            depth=depth_1,
-        )
-
-        for j, k2 in enumerate(images.keys()):
-            if i == j and not cosine_weighted:
-                continue
-
-            # load second image, camera and depth map
-            image_2 = images[k2]
-            camera_2 = cameras[image_2.camera_id]
-            depth_map_2 = load_depth_map(os.path.join(depth_path, f"{image_2.name}.geometric.bin"))
-
-            # project all 3D points to image 2 to obtain 2D points and associated depth values
-            proj_points_2d, proj_depths, proj_mask = forward_project(  # type: ignore
-                points_3d=points_3d,
-                image=image_2,
-                camera=camera_2,
-            )
-
-            # get corresponding depth values from the second depth map
-            # depth map values are stored row-wise => first index with y-coordinate
-            depth_2 = depth_map_2[proj_points_2d[:, 1], proj_points_2d[:, 0]]
-
-            # compute inliers based on the absolute relative depth errors
-            abs_rel_error = np.abs(depth_2 / proj_depths - 1.0)
-            if cosine_weighted:
-                normal_map_1 = load_depth_map(
-                    os.path.join(str(normal_path), f"{image_1.name}.geometric.bin")
-                )
-                normal_map_2 = load_depth_map(
-                    os.path.join(str(normal_path), f"{image_2.name}.geometric.bin")
-                )
-                norm_1 = normal_map_1[
-                    points_2d[proj_mask][:, 1].astype(int), points_2d[proj_mask][:, 0].astype(int)
-                ]
-                norm_2 = normal_map_2[proj_points_2d[:, 1], proj_points_2d[:, 0]]
-                cos_w_2 = np.minimum(np.abs(norm_1[:, 2]), np.abs(norm_2[:, 2]))
-                n_inliners = np.sum(cos_w_2[abs_rel_error < rel_thresh])
-            else:
-                n_inliners = np.count_nonzero(abs_rel_error < rel_thresh)
-
-            # final score
-            scores[i, j] = np.rint(100 * n_inliners / n_features)
+        # TODO: tqdm doesn't show a progress bar here...
+        for future in tqdm(as_completed(futures), desc="Computing dense overlap...", ncols=80):
+            index, row = future.result()
+            scores[index, :] = row
 
     # create and return data array
     coords = {"img1": image_fns, "img2": image_fns}

--- a/megadepth/pipelines/pipeline.py
+++ b/megadepth/pipelines/pipeline.py
@@ -116,7 +116,7 @@ class Pipeline:
         self.paths.metrics.mkdir(exist_ok=True, parents=True)
 
         collect_metrics(self.paths, self.config, model_type="sparse")
-        # collect_metrics(self.paths, self.config, model_type=ModelType.DENSE)
+        collect_metrics(self.paths, self.config, model_type="dense")
 
     def run(self) -> None:
         """Run the pipeline."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ scikit-image
 transformers
 hydra-core
 check_orientation
+xarray
 git+https://github.com/CSAILVision/semantic-segmentation-pytorch.git@master


### PR DESCRIPTION
### To Do

- [x] Update sparse overlap (xarray, data type)
- [x] Update dense overlap (xarray, data type, docstrings etc.)
- [x] Implement multiprocessing for dense overlap (sparse overlap is fast enough)
- [x] Verify that the multiprocessing code produces identical results as the sequential code

### Contributions

- Converted the data type of the overlap scores from float64 to int8. This reduces the required storage by 8x (huge difference for large scenes). All values are now in the range [0, 100] instead of [0.0, 1.0]. The lost precision is irrelevant as our scores are only rough approximations to the actual overlaps anyway.
- Some registered images may not end up in the final dataset, e.g. because of of too few depth values. This makes it even more difficult to work with the overlap matrices. Now, we use [xarray](https://docs.xarray.dev/en/stable/) to wrap the numpy arrays such that we can name the dimensions and assign image filenames as coordinate values along each dimension. This way, we can access a specific overlap using filenames instead of meaningless indices.